### PR TITLE
fix broken Glowstone readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Progress can be determined by the completeness of the to-do lists on the two pin
 
 ## Credits
 * [BukkitTeam](https://bukkit.org/), [Spigot](https://spigotmc.org/), and [Paper](https://papermc.io/) for their work on the API.
-* [Glowstone](https://glowstonemc.net) for the library loader.
+* [Glowstone](https://glowstone.net) for the library loader.
 * [md_5's SpecialSource](https://github.com/md-5/SpecialSource), [SrgLib by Techcable & Orion](https://github.com/OrionMinecraft/SrgLib), [MinecraftMapping by Phase](https://github.com/phase/MinecraftMapping/)
 
 # Apex Hosting 


### PR DESCRIPTION
glowstone.net, not glowstonemc.net :)