### PR TITLE
feat: fire entity damage events so plugins can change or cancel damage (1.21.11)

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -30,6 +30,7 @@ import org.cardboardpowered.CardboardMod;
 import org.cardboardpowered.extras.PlayerList_LoginResult;
 import org.cardboardpowered.BukkitLogger;
 import org.cardboardpowered.bridge.world.entity.EntityBridge;
+import org.cardboardpowered.bridge.world.damagesource.DamageSourceBridge;
 import org.cardboardpowered.bridge.world.ContainerBridge;
 import org.cardboardpowered.bridge.world.entity.LivingEntityBridge;
 import org.cardboardpowered.bridge.server.MinecraftServerBridge;
@@ -56,6 +57,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.Animal;
@@ -945,6 +947,75 @@ public class CraftEventFactory {
     	PlayerExpCooldownChangeEvent event = new PlayerExpCooldownChangeEvent(player, newCooldown, changeReason);
     	Bukkit.getPluginManager().callEvent(event);
     	return event;
+    }
+
+    /**
+     * Fires the Bukkit damage event for a Minecraft damage.
+     * Becomes an {@link EntityDamageByEntityEvent} whenever something directly dealt the damage,
+     * so a projectile hit reports the projectile as the damager, like Spigot does.
+     *
+     * The caller must honour the returned event: skip the damage when it is cancelled, and apply
+     * {@link EntityDamageEvent#getDamage()} instead of the amount it was handed.
+     */
+    public static EntityDamageEvent callEntityDamageEvent(Entity victim, DamageSource source, float amount) {
+        CraftEntity damagee = ((EntityBridge) victim).getBukkitEntity();
+        org.bukkit.damage.DamageSource bukkitSource = new CraftDamageSource(source);
+        EntityDamageEvent.DamageCause cause = getDamageCause(source);
+
+        Entity damager = source.getDirectEntity();
+        EntityDamageEvent event = (damager == null)
+                ? new EntityDamageEvent(damagee, cause, bukkitSource, amount)
+                : new EntityDamageByEntityEvent(((EntityBridge) damager).getBukkitEntity(), damagee, cause, bukkitSource, amount);
+
+        Bukkit.getPluginManager().callEvent(event);
+        return event;
+    }
+
+    public static EntityDamageEvent.DamageCause getDamageCause(DamageSource source) {
+        if (source.is(DamageTypes.IN_FIRE)) return EntityDamageEvent.DamageCause.FIRE;
+        if (source.is(DamageTypes.CAMPFIRE)) return EntityDamageEvent.DamageCause.CAMPFIRE;
+        if (source.is(DamageTypes.ON_FIRE)) return EntityDamageEvent.DamageCause.FIRE_TICK;
+        if (source.is(DamageTypes.LAVA)) return EntityDamageEvent.DamageCause.LAVA;
+        if (source.is(DamageTypes.HOT_FLOOR)) return EntityDamageEvent.DamageCause.HOT_FLOOR;
+        if (source.is(DamageTypes.LIGHTNING_BOLT)) return EntityDamageEvent.DamageCause.LIGHTNING;
+        if (source.is(DamageTypes.IN_WALL)) return EntityDamageEvent.DamageCause.SUFFOCATION;
+        if (source.is(DamageTypes.CRAMMING)) return EntityDamageEvent.DamageCause.CRAMMING;
+        if (source.is(DamageTypes.DROWN)) return EntityDamageEvent.DamageCause.DROWNING;
+        if (source.is(DamageTypes.STARVE)) return EntityDamageEvent.DamageCause.STARVATION;
+        if (source.is(DamageTypes.CACTUS) || source.is(DamageTypes.SWEET_BERRY_BUSH) || source.is(DamageTypes.STALAGMITE))
+            return EntityDamageEvent.DamageCause.CONTACT;
+        if (source.is(DamageTypes.FALL) || source.is(DamageTypes.ENDER_PEARL)) return EntityDamageEvent.DamageCause.FALL;
+        if (source.is(DamageTypes.FLY_INTO_WALL)) return EntityDamageEvent.DamageCause.FLY_INTO_WALL;
+        if (source.is(DamageTypes.FELL_OUT_OF_WORLD)) return EntityDamageEvent.DamageCause.VOID;
+        if (source.is(DamageTypes.OUTSIDE_BORDER)) return EntityDamageEvent.DamageCause.WORLD_BORDER;
+        if (source.is(DamageTypes.MAGIC) || source.is(DamageTypes.INDIRECT_MAGIC)) return EntityDamageEvent.DamageCause.MAGIC;
+        if (source.is(DamageTypes.WITHER)) return EntityDamageEvent.DamageCause.WITHER;
+        if (source.is(DamageTypes.DRAGON_BREATH)) return EntityDamageEvent.DamageCause.DRAGON_BREATH;
+        if (source.is(DamageTypes.DRY_OUT)) return EntityDamageEvent.DamageCause.DRYOUT;
+        if (source.is(DamageTypes.FREEZE)) return EntityDamageEvent.DamageCause.FREEZE;
+        if (source.is(DamageTypes.FALLING_BLOCK) || source.is(DamageTypes.FALLING_ANVIL) || source.is(DamageTypes.FALLING_STALACTITE))
+            return EntityDamageEvent.DamageCause.FALLING_BLOCK;
+        if (source.is(DamageTypes.THORNS)) return EntityDamageEvent.DamageCause.THORNS;
+        if (source.is(DamageTypes.SONIC_BOOM)) return EntityDamageEvent.DamageCause.SONIC_BOOM;
+        if (source.is(DamageTypes.GENERIC_KILL)) return EntityDamageEvent.DamageCause.KILL;
+        if (source.is(DamageTypes.BAD_RESPAWN_POINT)) return EntityDamageEvent.DamageCause.BLOCK_EXPLOSION;
+        if (source.is(DamageTypes.FIREWORKS) || source.is(DamageTypes.PLAYER_EXPLOSION)) return EntityDamageEvent.DamageCause.ENTITY_EXPLOSION;
+        if (source.is(DamageTypes.EXPLOSION))
+            return (source.getEntity() == null) ? EntityDamageEvent.DamageCause.BLOCK_EXPLOSION : EntityDamageEvent.DamageCause.ENTITY_EXPLOSION;
+        if (source.is(DamageTypes.ARROW) || source.is(DamageTypes.TRIDENT) || source.is(DamageTypes.MOB_PROJECTILE)
+                || source.is(DamageTypes.SPIT) || source.is(DamageTypes.THROWN) || source.is(DamageTypes.WIND_CHARGE)
+                || source.is(DamageTypes.FIREBALL) || source.is(DamageTypes.UNATTRIBUTED_FIREBALL) || source.is(DamageTypes.WITHER_SKULL))
+            return EntityDamageEvent.DamageCause.PROJECTILE;
+        if (((DamageSourceBridge) source).isSweep_BF()) return EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK;
+        if (source.is(DamageTypes.STING) || source.is(DamageTypes.MOB_ATTACK) || source.is(DamageTypes.MOB_ATTACK_NO_AGGRO)
+                || source.is(DamageTypes.PLAYER_ATTACK) || source.is(DamageTypes.MACE_SMASH) || source.is(DamageTypes.SPEAR))
+            return EntityDamageEvent.DamageCause.ENTITY_ATTACK;
+
+        // Datapack (or otherwise unmapped) damage types: go by what actually dealt the damage.
+        if (source.getDirectEntity() != null && source.getDirectEntity() != source.getEntity())
+            return EntityDamageEvent.DamageCause.PROJECTILE;
+        if (source.getEntity() != null) return EntityDamageEvent.DamageCause.ENTITY_ATTACK;
+        return EntityDamageEvent.DamageCause.CUSTOM;
     }
 
     public static <T> CraftEventFactory.GameRuleSetResult<T> handleGameRuleSet(GameRule<T> rule, T value, ServerLevel level, @Nullable CommandSender sender) {

--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -30,7 +30,6 @@ import org.cardboardpowered.CardboardMod;
 import org.cardboardpowered.extras.PlayerList_LoginResult;
 import org.cardboardpowered.BukkitLogger;
 import org.cardboardpowered.bridge.world.entity.EntityBridge;
-import org.cardboardpowered.bridge.world.damagesource.DamageSourceBridge;
 import org.cardboardpowered.bridge.world.ContainerBridge;
 import org.cardboardpowered.bridge.world.entity.LivingEntityBridge;
 import org.cardboardpowered.bridge.server.MinecraftServerBridge;
@@ -1006,7 +1005,6 @@ public class CraftEventFactory {
                 || source.is(DamageTypes.SPIT) || source.is(DamageTypes.THROWN) || source.is(DamageTypes.WIND_CHARGE)
                 || source.is(DamageTypes.FIREBALL) || source.is(DamageTypes.UNATTRIBUTED_FIREBALL) || source.is(DamageTypes.WITHER_SKULL))
             return EntityDamageEvent.DamageCause.PROJECTILE;
-        if (((DamageSourceBridge) source).isSweep_BF()) return EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK;
         if (source.is(DamageTypes.STING) || source.is(DamageTypes.MOB_ATTACK) || source.is(DamageTypes.MOB_ATTACK_NO_AGGRO)
                 || source.is(DamageTypes.PLAYER_ATTACK) || source.is(DamageTypes.MACE_SMASH) || source.is(DamageTypes.SPEAR))
             return EntityDamageEvent.DamageCause.ENTITY_ATTACK;

--- a/src/main/java/org/cardboardpowered/bridge/world/entity/DamageEventBridge.java
+++ b/src/main/java/org/cardboardpowered/bridge/world/entity/DamageEventBridge.java
@@ -1,0 +1,14 @@
+package org.cardboardpowered.bridge.world.entity;
+
+/**
+ * Shared re-entrancy flag for the damage events. Set while a hit is being re-applied with the
+ * amount a plugin asked for, so the event fires once per hit no matter which hurtServer override
+ * caught it. Lives on LivingEntity, so players inherit it.
+ */
+public interface DamageEventBridge {
+
+    boolean cardboard$isApplyingEventDamage();
+
+    void cardboard$setApplyingEventDamage(boolean applying);
+
+}

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin_DamageEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin_DamageEvent.java
@@ -1,0 +1,62 @@
+package org.cardboardpowered.mixin.world.entity;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import org.bukkit.craftbukkit.event.CraftEventFactory;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Fires EntityDamageEvent / EntityDamageByEntityEvent so plugins can cancel or rescale damage.
+ */
+@Mixin(LivingEntity.class)
+public class LivingEntityMixin_DamageEvent {
+
+    @Shadow protected float lastHurt;
+
+    // Set while re-entering hurtServer with the damage the event asked for, so the event fires once.
+    @Unique private boolean cardboard$applyingEventDamage = false;
+
+    @Inject(at = @At("HEAD"), method = "hurtServer", cancellable = true)
+    private void cardboard_doEntityDamageEvent(ServerLevel world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (this.cardboard$applyingEventDamage) return;
+
+        LivingEntity self = (LivingEntity) (Object) this;
+
+        // Vanilla drops these on the floor before doing anything, so there is no damage to report.
+        if (self.isInvulnerableTo(world, source) || self.isDeadOrDying()) return;
+        if (source.is(DamageTypeTags.IS_FIRE) && self.hasEffect(MobEffects.FIRE_RESISTANCE)) return;
+
+        float damage = Math.max(amount, 0.0F);
+
+        // The hurt cooldown swallows anything that isn't stronger than the hit we are still recovering from.
+        if (self.invulnerableTime > 10 && !source.is(DamageTypeTags.BYPASSES_COOLDOWN) && damage <= this.lastHurt) return;
+
+        EntityDamageEvent event = CraftEventFactory.callEntityDamageEvent(self, source, damage);
+        if (event.isCancelled()) {
+            cir.setReturnValue(false);
+            return;
+        }
+
+        // Note: the event carries the damage before shield blocking and armor, which is what
+        // setDamage(double) overrides; the remaining reductions still apply on top of it.
+        float newDamage = (float) event.getDamage();
+        if (newDamage == damage) return;
+
+        this.cardboard$applyingEventDamage = true;
+        try {
+            cir.setReturnValue(self.hurtServer(world, source, newDamage));
+        } finally {
+            this.cardboard$applyingEventDamage = false;
+        }
+    }
+
+}

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin_DamageEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/LivingEntityMixin_DamageEvent.java
@@ -7,6 +7,7 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.cardboardpowered.bridge.world.entity.DamageEventBridge;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -18,12 +19,22 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * Fires EntityDamageEvent / EntityDamageByEntityEvent so plugins can cancel or rescale damage.
  */
 @Mixin(LivingEntity.class)
-public class LivingEntityMixin_DamageEvent {
+public class LivingEntityMixin_DamageEvent implements DamageEventBridge {
 
     @Shadow protected float lastHurt;
 
     // Set while re-entering hurtServer with the damage the event asked for, so the event fires once.
     @Unique private boolean cardboard$applyingEventDamage = false;
+
+    @Override
+    public boolean cardboard$isApplyingEventDamage() {
+        return this.cardboard$applyingEventDamage;
+    }
+
+    @Override
+    public void cardboard$setApplyingEventDamage(boolean applying) {
+        this.cardboard$applyingEventDamage = applying;
+    }
 
     @Inject(at = @At("HEAD"), method = "hurtServer", cancellable = true)
     private void cardboard_doEntityDamageEvent(ServerLevel world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/player/PlayerMixin_DamageEvent.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/player/PlayerMixin_DamageEvent.java
@@ -1,0 +1,52 @@
+package org.cardboardpowered.mixin.world.entity.player;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Player;
+import org.bukkit.craftbukkit.event.CraftEventFactory;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.cardboardpowered.bridge.world.entity.DamageEventBridge;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Player#hurtServer ends with {@code f == 0.0F ? false : super.hurtServer(...)}, so a hit that
+ * deals no damage — a snowball or a thrown egg — never reaches LivingEntity#hurtServer, where the
+ * damage events are fired. Fire the event here for that case, and let the hit through when a plugin
+ * turns it into real damage. Mobs need none of this: nothing filters a zero out on their way down.
+ */
+@Mixin(Player.class)
+public class PlayerMixin_DamageEvent {
+
+    @Inject(at = @At("HEAD"), method = "hurtServer", cancellable = true)
+    private void cardboard_doZeroDamageEvent(ServerLevel world, DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if (amount != 0.0F) return; // Real damage reaches the event on its own.
+
+        Player self = (Player) (Object) this;
+        DamageEventBridge bridge = (DamageEventBridge) self;
+        if (bridge.cardboard$isApplyingEventDamage()) return;
+
+        // The same guards vanilla applies before it gets to the zero check.
+        if (self.isInvulnerableTo(world, source)) return;
+        if (self.getAbilities().invulnerable && !source.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) return;
+        if (self.isDeadOrDying()) return;
+
+        // Difficulty scaling sits between here and the zero check, and leaves a zero a zero.
+        EntityDamageEvent event = CraftEventFactory.callEntityDamageEvent(self, source, 0.0F);
+        if (event.isCancelled() || event.getDamage() == 0.0D) {
+            cir.setReturnValue(false); // What vanilla would have returned.
+            return;
+        }
+
+        bridge.cardboard$setApplyingEventDamage(true);
+        try {
+            cir.setReturnValue(self.hurtServer(world, source, (float) event.getDamage()));
+        } finally {
+            bridge.cardboard$setApplyingEventDamage(false);
+        }
+    }
+
+}

--- a/src/main/java/org/cardboardpowered/mixin/world/entity/projectile/throwableitemprojectile/ThrownEggMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/projectile/throwableitemprojectile/ThrownEggMixin.java
@@ -30,7 +30,12 @@ public abstract class ThrownEggMixin {
 
     private final Random random = new Random();
 
-    @Inject(at = @At(shift = Shift.AFTER, value = "HEAD"), method = "onHit", cancellable = true)
+    // Injected after the super call, not at HEAD: super.onHit is what dispatches onHitEntity and
+    // onHitBlock, so cancelling before it stops the egg hitting anything at all. Everything after
+    // the super call is what this handler replaces.
+    @Inject(method = "onHit", cancellable = true,
+            at = @At(value = "INVOKE", shift = Shift.AFTER,
+                    target = "Lnet/minecraft/world/entity/projectile/throwableitemprojectile/ThrowableItemProjectile;onHit(Lnet/minecraft/world/phys/HitResult;)V"))
     public void cardboard_doEggThrowEvent(HitResult res, CallbackInfo ci) {
         ThrownEgg egg = (ThrownEgg)(Object)this;
         Level world = egg.level();

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -83,6 +83,7 @@
     "world.entity.ExperienceOrbMixin",
     "world.entity.ItemBasedSteeringMixin",
     "world.entity.LivingEntityMixin",
+    "world.entity.LivingEntityMixin_DamageEvent",
     "world.entity.MobMixin",
     "world.entity.ai.attributes.AttributeMapMixin",
     "world.entity.ai.behavior.AssignProfessionFromJobSiteMixin",

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -111,6 +111,7 @@
     "world.entity.npc.villager.AbstractVillagerMixin",
     "world.entity.player.InventoryMixin",
     "world.entity.player.PlayerMixin",
+    "world.entity.player.PlayerMixin_DamageEvent",
     "world.entity.projectile.FireworkRocketEntityMixin",
     "world.entity.projectile.ProjectileMixin",
     "world.entity.projectile.arrow.AbstractArrowMixin",


### PR DESCRIPTION
### The problem

Cardboard never fires `EntityDamageEvent`, and never fires `EntityDamageByEntityEvent`. Before this patch nothing in the tree even mentioned them:

```
$ git grep -c "EntityDamageByEntityEvent" ver/1.21.11 -- src/main/java | wc -l
0
```

`CraftEventFactory` has damage plumbing for death only — `callPlayerDeathEvent` and `callEntityDeathEvent` — so a plugin can see that something died, but nothing can see, scale, or stop the hit that killed it. Every plugin built on damage is silently inert: PvP toggles, region protection, arena and minigame damage rules, anti-grief, custom weapon damage.

The one that led me here is [SnowballDamage](https://github.com/Derec-Mods/SnowballDamage), which restores pre-1.9 snowball/egg damage. Its whole implementation is one listener:

```java
@EventHandler(priority = EventPriority.NORMAL)
public void onEntityHit(EntityDamageByEntityEvent e) {
    if (e.getDamager() instanceof Snowball) e.setDamage(snowballDamage);
    if (e.getDamager() instanceof Egg)      e.setDamage(eggDamage);
}
```

It needs the event to fire at all, the *projectile* to be reported as `getDamager()`, and `setDamage()` to be honoured. Everything else it touches — `JavaPlugin`, `saveDefaultConfig()`, `getConfig()`, `Bukkit.getConsoleSender()`, bungee `ChatColor`, `CraftSnowball`/`CraftEgg` — already worked.

Firing the event turned out not to be enough, because two separate paths throw a hit away before it can ever reach one. Both only bite when the hit deals no damage on its own, which is exactly the case this plugin exists for:

**Thrown eggs never damaged anything, event or not.** `ThrownEggMixin` cancels `ThrownEgg#onHit` at `HEAD` to fire `PlayerEggThrowEvent`/`ThrownEggHatchEvent` and reimplement the hatching. But `HEAD` is before the super call, and that super call is the whole hit dispatch:

```
protected void onHit(net.minecraft.world.phys.HitResult);
       0: aload_0
       1: aload_1
       2: invokespecial  ThrowableItemProjectile.onHit:(Lnet/minecraft/world/phys/HitResult;)V   // <- cancelled away
       5: aload_0
       6: invokevirtual  level:()Lnet/minecraft/world/level/Level;      // hatching starts here
```

`Projectile#onHit` is the only caller of `onHitEntity`, which is where `ThrownEgg` calls `hurt(...)`. Cancelling ahead of it means an egg has never damaged an entity on Cardboard, and `ProjectileHitEvent` (injected on `Projectile#onHit`) never fired for eggs either.

**A zero-damage hit on a player is dropped before the event site.** `Player#hurtServer` ends with:

```java
return f == 0.0F ? false : super.hurtServer(serverLevel, damageSource, f);
```

A snowball deals `entity instanceof Blaze ? 3 : 0` and an egg deals `0.0F`, so for a player the call returns `false` right there and `LivingEntity#hurtServer` — where the event fires — is never reached. This is why the plugin worked on mobs but did nothing to players: nothing filters a zero out on a mob's way down.

### The fix

**`CraftEventFactory.callEntityDamageEvent(Entity, DamageSource, float)`** builds and dispatches the event. When the damage has a direct entity behind it, it becomes an `EntityDamageByEntityEvent` whose damager is `source.getDirectEntity()` — so an arrow or snowball hit reports the projectile, and plugins reach the shooter through `((Projectile) damager).getShooter()`, matching Spigot. Otherwise it is a plain `EntityDamageEvent`. Both carry a `CraftDamageSource`, which already existed and was only used for death events until now.

**`CraftEventFactory.getDamageCause(DamageSource)`** maps the damage type to `DamageCause`, through `DamageSource.is(ResourceKey)` against `DamageTypes` rather than string-matching `getMsgId()`, covering every vanilla type. `explosion` splits on whether there is a causing entity (`ENTITY_EXPLOSION` vs `BLOCK_EXPLOSION`); datapack types that match nothing fall back on what dealt the damage — a direct entity that is not the causing entity reads as `PROJECTILE`, a causing entity as `ENTITY_ATTACK`, otherwise `CUSTOM`.

**`LivingEntityMixin_DamageEvent`** fires it, injecting at the `HEAD` of `LivingEntity.hurtServer`. Two details matter there:

- *Vanilla's early-outs come first.* `hurtServer` drops damage on the floor for an invulnerable or already-dying entity, and for fire damage against fire resistance; the hurt-cooldown branch drops anything not stronger than the hit still being recovered from (`f <= this.lastHurt`). The mixin repeats those four checks before firing, so plugins are not handed damage that was never going to land. This also matches where CraftBukkit fires the event — after the cooldown gate, not before it.
- *A changed amount re-enters `hurtServer` once.* Rather than rely on injector ordering between a callback and a `@ModifyVariable` at the same injection point, the callback re-invokes `hurtServer` with the amount the event asked for behind a re-entrancy flag and returns that result. Armour, absorption, knockback, hurt sounds, advancement triggers and death handling then run exactly once, through vanilla, on the new number. A cancelled event returns `false` and nothing else runs.

**`ThrownEggMixin`** moves its injection point from `HEAD` to just after that `invokespecial`, so vanilla's hit dispatch runs and the handler still replaces exactly the tail it was written to replace. Eggs now damage what they hit, and `ProjectileHitEvent` fires for them.

**`PlayerMixin_DamageEvent`** covers the zero-damage filter: on `Player#hurtServer` with `amount == 0`, past the same guards vanilla applies before the filter (`isInvulnerableTo`, creative `abilities.invulnerable` unless the type bypasses it, `isDeadOrDying`), it fires the event and re-enters with whatever the plugin set. Difficulty scaling sits between there and the filter and leaves a zero a zero, so there is nothing to mirror. The re-entrancy flag is shared with the `LivingEntity` hook through `DamageEventBridge` so one hit still produces one event — a per-entity flag rather than a static, so nested damage (thorns, for one) is not swallowed.

### Testing

Real server on both branches (`gradlew runServer`) with SnowballDamage installed at its default config (`Snowballs.Damage: 3.0`, `Eggs.Damage: 3.0`), throwing actual projectiles rather than synthesising the damage:

```
gamerule doDaylightCycle false
time set midnight                        # or the zombie burns and pollutes the numbers
forceload add 0 0                        # or nothing ticks
summon zombie 0 100 0 {Tags:["z"],NoAI:1b,NoGravity:1b}
summon egg 0 101 3 {NoGravity:1b,Motion:[0.0d,0.0d,-0.6d]}
```

| | health |
|---|---|
| control window, 4s, nothing thrown | 20.0 → **20.0** |
| thrown egg | 20.0 → **17.06** |
| snowball | 17.06 → **14.12** |
| plain `damage @e[tag=z] 5` | 20.0 → **15.0** |

The control window is there because the first numbers I took were nonsense — a zombie standing in daylight burns, and 1 HP/s reads a lot like a projectile landing. Vanilla deals 0 to anything that is not a Blaze, so before this patch both projectile rows stayed at 20 (eggs did nothing at all, and snowballs only reached the event once it existed). `2.94` rather than `3.00` is the zombie's armour taking its cut afterwards. The last row is the regression check: unmodified damage falls straight through and lands once, not twice.

`gradlew build` passes on both branches. Both injectors were confirmed applied by exporting the transformed classes (`-Dmixin.debug.export=true`) and reading them back — `handler$…$cardboard_doZeroDamageEvent` sits at the head of `Player#hurtServer` in the exported class, ahead of the vanilla guards.

Not covered: the player side is verified from the bytecode and the applied injector, not in game — a player target needs a real client connecting, which the harness has no way to drive. Worth a look from anyone who can throw a snowball at someone.

### Not covered

- **Non-living entities.** `Entity.hurtServer` is abstract and armour stands, boats, item frames, end crystals and the rest each implement their own; only `LivingEntity` is hooked here, so damage to those still fires nothing. They need one hook each and are worth a follow-up.
- **Damage before reductions.** The event reports the amount as it enters `hurtServer` — before shield blocking, armour and enchantments, which still apply on top of whatever the plugin sets. CraftBukkit reports it after blocking.
- **`DamageModifier` maps.** The constructor used here populates `BASE` only, so `setDamage(double)`, `getDamage()` and `getFinalDamage()` behave, while `setDamage(DamageModifier.ARMOR, …)` still throws — as it does on any event built this way. Populating the full modifier map means reproducing vanilla's reduction maths in the event, which is a larger change than this.
- **`ENTITY_SWEEP_ATTACK`.** The cause mapper has no arm for it: `DamageSourceBridge#sweep_BF`, the existing hook that would mark a sweep, has no callers anywhere in the tree, so the branch could never be reached and I dropped it rather than leave dead code behind. Sweep hits currently report `ENTITY_ATTACK`.
