### PR TITLE
fix: stop goats crashing the ram behavior mixin

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/PrepareRamNearestTargetMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/ai/behavior/PrepareRamNearestTargetMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.behavior.PrepareRamNearestTarget;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
 import org.bukkit.event.entity.EntityTargetEvent;
-import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(PrepareRamNearestTarget.class)
 public class PrepareRamNearestTargetMixin {
 
-    @Inject(method = "method_36270",
+    @Inject(method = "lambda$start$2",
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/world/entity/ai/behavior/PrepareRamNearestTarget;chooseRamPosition(Lnet/minecraft/world/entity/PathfinderMob;Lnet/minecraft/world/entity/LivingEntity;)V"), cancellable = true)
     private void targetEvent(PathfinderMob pathAwareEntity, LivingEntity mob, CallbackInfo ci) {
@@ -24,7 +23,6 @@ public class PrepareRamNearestTargetMixin {
         if (event.isCancelled() || event.getTarget() == null) {
             ci.cancel();
         }
-        mob = ((CraftLivingEntity) event.getTarget()).getHandle();
         // CraftBukkit end
     }
 }


### PR DESCRIPTION
## Problem

Every goat fails to load or spawn on 26.1.2. `PrepareRamNearestTargetMixin` selects its target method by the old Yarn intermediary name `method_36270`, but this build runs on unobfuscated names and loads no refMap, so the selector matches nothing and the mixin fails to apply — taking the whole class down with it:

```
Critical injection failure: @Inject annotation on targetEvent could not find any targets
matching 'method_36270' in net/minecraft/world/entity/ai/behavior/PrepareRamNearestTarget.
No refMap loaded.
...
at net.minecraft.world.entity.animal.goat.GoatAi.initRamActivity(GoatAi.java:132)
```

## Fix

The real target is the lambda in `start()` that calls `chooseRamPosition`, confirmed against `minecraft-merged-deobf-26.1.2.jar`:

```
private void lambda$start$2(PathfinderMob, LivingEntity)
    ...
    3: invokevirtual chooseRamPosition:(LPathfinderMob;LLivingEntity;)V
```

Its descriptor already matches the handler, so the change is just the selector: `method_36270` → `lambda$start$2`.

Also removed the line after `ci.cancel()`:

```java
mob = ((CraftLivingEntity) event.getTarget()).getHandle();
```

`ci.cancel()` does not return, so this threw a `NullPointerException` on exactly the branch where `event.getTarget() == null` — and it was dead code anyway, since assigning a local in an `@Inject` handler cannot change the target in the injected method.

## Scope

Cancelling `EntityTargetEvent` now works. Retargeting via `event.setTarget(...)` still does not apply — that needs a `@Redirect`/`@ModifyArg` on the `chooseRamPosition` call plus an `@Invoker` (the method is private), which is left for a follow-up.

`AssignProfessionFromJobSiteMixin` has the same stale-selector problem (`method_46891`), but its body is commented out so it does not fail. Its current target is `lambda$create$6(Villager, ServerLevel, Holder$Reference)`, for whenever `VillagerCareerChangeEvent` gets enabled.

## Testing

`gradlew compileJava` passes.