### PR TITLE
fix: make the unknown target reason warning informative and rate-limited

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/MobMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/MobMixin.java
@@ -48,7 +48,7 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
                 reason = this.getTarget().isAlive() ? EntityTargetEvent.TargetReason.FORGOT_TARGET : EntityTargetEvent.TargetReason.TARGET_DIED;
             }
             if (reason == EntityTargetEvent.TargetReason.UNKNOWN) {
-                ((ServerLevelBridge)this.level()).getCraftServer().getLogger().log(java.util.logging.Level.WARNING, "Unknown target reason, please report on the issue tracker", new Exception());
+                cardboard$warnUnknownTargetReason(target);
             }
             CraftLivingEntity ctarget = null;
             if (target != null) {
@@ -69,4 +69,48 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
         return true;
         // CraftBukkit end
     }
+
+    // Cardboard start - the warning below fires from vanilla/mod code paths that have no mapped
+    // TargetReason, which can happen every tick for every mob. Log each distinct call site once.
+    @org.spongepowered.asm.mixin.Unique
+    private static final java.util.Set<String> cardboard$reportedUnknownTargetSites = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    @org.spongepowered.asm.mixin.Unique
+    private void cardboard$warnUnknownTargetReason(@Nullable LivingEntity newTarget) {
+        java.util.List<StackWalker.StackFrame> callers = StackWalker.getInstance().walk(frames -> frames
+                .dropWhile(frame -> frame.getMethodName().startsWith("cardboard$")
+                        || frame.getMethodName().equals("setTargetCraftBukkit")
+                        || frame.getMethodName().equals("setTarget"))
+                .limit(4)
+                .collect(java.util.stream.Collectors.toList()));
+
+        String mobType = EntityType.getKey(this.getType()).toString();
+        String callSite = callers.isEmpty() ? "unknown" : callers.get(0).toString();
+        if (!cardboard$reportedUnknownTargetSites.add(mobType + '@' + callSite)) {
+            return;
+        }
+
+        StringBuilder message = new StringBuilder()
+                .append("Unknown EntityTargetEvent.TargetReason for ").append(mobType)
+                .append(" (uuid=").append(this.getUUID())
+                .append(", world=").append(this.level().dimension().identifier())
+                .append(", pos=").append(this.blockPosition().toShortString())
+                .append("), old target=").append(cardboard$describeTarget(this.getTarget()))
+                .append(", new target=").append(cardboard$describeTarget(newTarget))
+                .append("\n  called from:");
+        for (StackWalker.StackFrame frame : callers) {
+            message.append("\n    ").append(frame);
+        }
+        message.append("\n  Only the first occurrence per mob type and call site is logged.")
+                .append(" Please report this on the Cardboard issue tracker.");
+
+        ((ServerLevelBridge) this.level()).getCraftServer().getLogger()
+                .log(java.util.logging.Level.WARNING, message.toString());
+    }
+
+    @org.spongepowered.asm.mixin.Unique
+    private static String cardboard$describeTarget(@Nullable LivingEntity entity) {
+        return entity == null ? "none" : EntityType.getKey(entity.getType()) + "/" + entity.getUUID();
+    }
+    // Cardboard end
 }


### PR DESCRIPTION
## Problem

`Mob#setTarget` calls that reach `cardboard$setTarget` without a mapped `TargetReason` log:

```
[01:05:38] [Server thread/WARN]: Unknown target reason, please report on the issue tracker
```

with a bare `new Exception()` stack trace. This can happen every tick for every mob, so the log fills with millions of identical lines and the stack traces make it worse rather than actionable.

## Change

- Moved the warning into `cardboard$warnUnknownTargetReason`, which reports the mob type, uuid, world, block position, old target and new target, plus the top 4 caller frames (our own mixin frames skipped).
- Rate limiting: each distinct `(mob type, call site)` pair is reported only once per server run, so a genuinely new code path is still surfaced while the per-tick spam is gone.

Example output:

```
Unknown EntityTargetEvent.TargetReason for minecraft:zombie (uuid=..., world=minecraft:overworld, pos=12, 64, -30), old target=none, new target=minecraft:player/...
  called from:
    net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal.start(NearestAttackableTargetGoal.java:123)
    ...
  Only the first occurrence per mob type and call site is logged. Please report this on the Cardboard issue tracker.
```

## Note (not addressed here)

`setTargetCraftBukkit` passes the current `target` field instead of the `livingEntity` argument to `cardboard$setTarget`, so the incoming target never reaches the event. That looks like a separate bug and is left untouched, since fixing it changes event behaviour.

## Testing

`./gradlew compileJava` passes.