### PR TITLE
refactor: move the server option parser out of MainMixin

### DIFF
--- a/src/main/java/org/cardboardpowered/CardboardOptions.java
+++ b/src/main/java/org/cardboardpowered/CardboardOptions.java
@@ -1,0 +1,154 @@
+package org.cardboardpowered;
+
+import static java.util.Arrays.asList;
+
+import java.io.File;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.util.PathConverter;
+
+/**
+ * Command line options accepted by the server, mirroring CraftBukkit's {@code Main}.
+ *
+ * <p>This lives outside of the mixin on purpose: anonymous classes declared inside a mixin get
+ * relocated into the target class as {@code Main$Anonymous$<hash>}, which makes Mixin log a
+ * "Error loading class" warning while resolving the class hierarchy.
+ *
+ * @implSpec https://github.com/PaperMC/Paper/blob/main/paper-server/patches/sources/net/minecraft/server/Main.java.patch
+ */
+public final class CardboardOptions {
+
+	private CardboardOptions() {
+	}
+
+	public static OptionSet parse(String[] args) {
+		return createParser().parse(args);
+	}
+
+	public static OptionParser createParser() {
+		OptionParser parser = new OptionParser();
+
+		parser.acceptsAll(asList("?", "help"), "Show the help");
+
+		parser.acceptsAll(asList("c", "config"), "Properties file to use")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("server.properties"))
+				.describedAs("Properties file");
+
+		parser.acceptsAll(asList("P", "plugins"), "Plugin directory to use")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("plugins"))
+				.describedAs("Plugin directory");
+
+		parser.acceptsAll(asList("h", "host", "server-ip"), "Host to listen on")
+				.withRequiredArg()
+				.ofType(String.class)
+				.describedAs("Hostname or IP");
+
+		parser.acceptsAll(asList("W", "world-dir", "universe", "world-container"), "World container")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("."))
+				.describedAs("Directory containing worlds");
+
+		parser.acceptsAll(asList("w", "world", "level-name"), "World name")
+				.withRequiredArg()
+				.ofType(String.class)
+				.describedAs("World name");
+
+		parser.acceptsAll(asList("p", "port", "server-port"), "Port to listen on")
+				.withRequiredArg()
+				.ofType(Integer.class)
+				.describedAs("Port");
+
+		parser.accepts("serverId", "Server ID")
+				.withRequiredArg();
+
+		parser.accepts("jfrProfile", "Enable JFR profiling");
+
+		parser.accepts("pidFile", "pid File")
+				.withRequiredArg()
+				.withValuesConvertedBy(new PathConverter());
+
+		parser.acceptsAll(asList("o", "online-mode"), "Whether to use online authentication")
+				.withRequiredArg()
+				.ofType(Boolean.class)
+				.describedAs("Authentication");
+
+		parser.acceptsAll(asList("s", "size", "max-players"), "Maximum amount of players")
+				.withRequiredArg()
+				.ofType(Integer.class)
+				.describedAs("Server size");
+
+		parser.acceptsAll(asList("b", "bukkit-settings"), "File for bukkit settings")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("bukkit.yml"))
+				.describedAs("Yml file");
+
+		parser.acceptsAll(asList("C", "commands-settings"), "File for command settings")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("commands.yml"))
+				.describedAs("Yml file");
+
+		parser.accepts("forceUpgrade", "Whether to force a world upgrade");
+		parser.accepts("eraseCache", "Whether to force cache erase during world upgrade");
+		parser.accepts("recreateRegionFiles", "Whether to recreate region files during world upgrade");
+		parser.accepts("safeMode", "Loads level with vanilla datapack only"); // Paper
+		parser.accepts("nogui", "Disables the graphical console");
+
+		parser.accepts("nojline", "Disables jline and emulates the vanilla console");
+
+		parser.accepts("noconsole", "Disables the console");
+
+		parser.acceptsAll(asList("v", "version"), "Show the CraftBukkit Version");
+
+		parser.accepts("demo", "Demo mode");
+
+		parser.accepts("bonusChest", "Enable the bonus chest");
+
+		parser.accepts("initSettings", "Only create configuration files and then exit"); // SPIGOT-5761: Add initSettings option
+
+		parser.acceptsAll(asList("S", "spigot-settings"), "File for spigot settings")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("spigot.yml"))
+				.describedAs("Yml file");
+
+		parser.acceptsAll(asList("paper-dir", "paper-settings-directory"), "Directory for Paper settings")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File(/*io.papermc.paper.configuration.PaperConfigurations.CONFIG_DIR*/ "config"))
+				.describedAs("Config directory");
+
+		parser.acceptsAll(asList("paper", "paper-settings"), "File for Paper settings")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File("paper.yml"))
+				.describedAs("Yml file");
+
+		parser.acceptsAll(asList("add-plugin", "add-extra-plugin-jar"), "Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File[] {})
+				.describedAs("Jar file");
+
+		parser.acceptsAll(asList("add-plugin-dir", "add-extra-plugin-dir"), "Specify paths to extra plugin directories to be loaded in addition to the plugins folder. This argument can be specified multiple times, once for each extra plugin dir path.")
+				.withRequiredArg()
+				.ofType(File.class)
+				.defaultsTo(new File[] {})
+				.describedAs("Plugin directory");
+
+		parser.accepts("server-name", "Name of the server")
+				.withRequiredArg()
+				.ofType(String.class)
+				.defaultsTo("Unknown Server")
+				.describedAs("Name");
+
+		return parser;
+	}
+}

--- a/src/main/java/org/cardboardpowered/mixin/server/MainMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/server/MainMixin.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.cardboardpowered.CardboardLogger;
 import org.cardboardpowered.CardboardMod;
+import org.cardboardpowered.CardboardOptions;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,17 +16,11 @@ import com.google.common.io.FileWriteMode;
 import com.google.common.io.Files;
 import com.llamalad7.mixinextras.sugar.Local;
 
-import io.papermc.paper.plugin.PluginInitializerManager;
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Main;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.world.level.storage.LevelStorageSource;
-
-import static java.util.Arrays.asList;
-import joptsimple.util.PathConverter;
 
 /**
  * Mixin of {@link net.minecraft.server.Main}
@@ -70,141 +65,14 @@ public class MainMixin {
 	        ),
 	        remap = false
 	    )
-	    private static void insertPluginInitializerLoad(String[] strings, CallbackInfo ci) {
-			org.cardboardpowered.BukkitLogger.getLogger().info("Loading Paper PluginInitializerManager..");
-	        
+	    private static void cardboard$parse_server_options(String[] strings, CallbackInfo ci) {
 	        try {
-	        	 OptionParser parser = new OptionParser() {
-	                 {
-	                     this.acceptsAll(asList("?", "help"), "Show the help");
-
-	                     this.acceptsAll(asList("c", "config"), "Properties file to use")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("server.properties"))
-	                             .describedAs("Properties file");
-
-	                     this.acceptsAll(asList("P", "plugins"), "Plugin directory to use")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("plugins"))
-	                             .describedAs("Plugin directory");
-
-	                     this.acceptsAll(asList("h", "host", "server-ip"), "Host to listen on")
-	                             .withRequiredArg()
-	                             .ofType(String.class)
-	                             .describedAs("Hostname or IP");
-
-	                     this.acceptsAll(asList("W", "world-dir", "universe", "world-container"), "World container")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("."))
-	                             .describedAs("Directory containing worlds");
-
-	                     this.acceptsAll(asList("w", "world", "level-name"), "World name")
-	                             .withRequiredArg()
-	                             .ofType(String.class)
-	                             .describedAs("World name");
-
-	                     this.acceptsAll(asList("p", "port", "server-port"), "Port to listen on")
-	                             .withRequiredArg()
-	                             .ofType(Integer.class)
-	                             .describedAs("Port");
-
-	                     this.accepts("serverId", "Server ID")
-	                             .withRequiredArg();
-
-	                     this.accepts("jfrProfile", "Enable JFR profiling");
-
-	                     this.accepts("pidFile", "pid File")
-	                             .withRequiredArg()
-	                             .withValuesConvertedBy(new PathConverter());
-
-	                     this.acceptsAll(asList("o", "online-mode"), "Whether to use online authentication")
-	                             .withRequiredArg()
-	                             .ofType(Boolean.class)
-	                             .describedAs("Authentication");
-
-	                     this.acceptsAll(asList("s", "size", "max-players"), "Maximum amount of players")
-	                             .withRequiredArg()
-	                             .ofType(Integer.class)
-	                             .describedAs("Server size");
-
-	                     this.acceptsAll(asList("b", "bukkit-settings"), "File for bukkit settings")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("bukkit.yml"))
-	                             .describedAs("Yml file");
-
-	                     this.acceptsAll(asList("C", "commands-settings"), "File for command settings")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("commands.yml"))
-	                             .describedAs("Yml file");
-
-	                     this.accepts("forceUpgrade", "Whether to force a world upgrade");
-	                     this.accepts("eraseCache", "Whether to force cache erase during world upgrade");
-	                     this.accepts("recreateRegionFiles", "Whether to recreate region files during world upgrade");
-	                     this.accepts("safeMode", "Loads level with vanilla datapack only"); // Paper
-	                     this.accepts("nogui", "Disables the graphical console");
-
-	                     this.accepts("nojline", "Disables jline and emulates the vanilla console");
-
-	                     this.accepts("noconsole", "Disables the console");
-
-	                     this.acceptsAll(asList("v", "version"), "Show the CraftBukkit Version");
-
-	                     this.accepts("demo", "Demo mode");
-
-	                     this.accepts("bonusChest", "Enable the bonus chest");
-
-	                     this.accepts("initSettings", "Only create configuration files and then exit"); // SPIGOT-5761: Add initSettings option
-
-	                     this.acceptsAll(asList("S", "spigot-settings"), "File for spigot settings")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("spigot.yml"))
-	                             .describedAs("Yml file");
-
-	                     this.acceptsAll(asList("paper-dir", "paper-settings-directory"), "Directory for Paper settings")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File(/*io.papermc.paper.configuration.PaperConfigurations.CONFIG_DIR*/ "config"))
-	                             .describedAs("Config directory");
-
-	                     this.acceptsAll(asList("paper", "paper-settings"), "File for Paper settings")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File("paper.yml"))
-	                             .describedAs("Yml file");
-
-	                     this.acceptsAll(asList("add-plugin", "add-extra-plugin-jar"), "Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File[] {})
-	                             .describedAs("Jar file");
-
-	                     this.acceptsAll(asList("add-plugin-dir", "add-extra-plugin-dir"), "Specify paths to extra plugin directories to be loaded in addition to the plugins folder. This argument can be specified multiple times, once for each extra plugin dir path.")
-	                             .withRequiredArg()
-	                             .ofType(File.class)
-	                             .defaultsTo(new File[] {})
-	                             .describedAs("Plugin directory");
-
-	                     this.accepts("server-name", "Name of the server")
-	                             .withRequiredArg()
-	                             .ofType(String.class)
-	                             .defaultsTo("Unknown Server")
-	                             .describedAs("Name");
-	                 }
-	             };
-	        	OptionSet options = parser.parse(strings);
-	        	CardboardMod.options = options;
-				// PluginInitializerManager.load(options);
-			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
+	            CardboardMod.options = CardboardOptions.parse(strings);
+	        } catch (Exception err) {
+	            CardboardLogger.getSLF4J().error("Could not parse the server command line options", err);
+	        }
 	    }
+
 
 	
 }


### PR DESCRIPTION
## Problem

Starting a server logs this on every boot:

```
[main/WARN]: Error loading class: net/minecraft/server/Main$Anonymous$2039727189863912b077f0aab954e602 (java.lang.ClassNotFoundException: net/minecraft/server/Main$Anonymous$2039727189863912b077f0aab954e602)
```

`MainMixin` built its `OptionParser` as an anonymous subclass with an instance initializer. Mixin relocates anonymous classes declared inside a mixin into the target class under a synthetic `Main$Anonymous$<hash>` name, and `ClassInfo` then fails to resolve that name while walking the class hierarchy — hence the warning. It is cosmetic, but it is noise on every startup and the underlying cause is ~120 lines of non-injection logic living inside a mixin.

## Change

- Move the option definitions verbatim into a new `org.cardboardpowered.CardboardOptions` (`createParser()` / `parse(String[])`). No option, alias, type or default was changed.
- `MainMixin` drops from 210 to ~78 lines; the injection is now just the parse call.

Drive-by cleanups in the same injection:

- Renamed `insertPluginInitializerLoad` → `cardboard$parse_server_options`. It never loaded anything — `PluginInitializerManager.load(options)` is called from `CardboardMod`, and this matches the naming of the neighbouring injection.
- Removed the `"Loading Paper PluginInitializerManager.."` log line, which announced work that did not happen here, and the dead `// PluginInitializerManager.load(options);` comment.
- Replaced `e.printStackTrace()` + `// TODO Auto-generated catch block` with `CardboardLogger.getSLF4J().error(...)`.
- Removed imports that became unused.

## Testing

`./gradlew compileJava` passes. Behaviour is unchanged — the same `OptionSet` is still assigned to `CardboardMod.options` — so the warning disappearing on startup is the only observable difference.