### PR TITLE
fix: stop mushroom cow shearing crashing and losing its drops

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/animal/cow/MushroomCowMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/animal/cow/MushroomCowMixin.java
@@ -4,14 +4,17 @@ import org.cardboardpowered.util.MixinInfo;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.animal.cow.MushroomCow;
-import net.minecraft.world.entity.animal.sheep.Sheep;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.bukkit.craftbukkit.event.CraftEventFactory;
+import org.cardboardpowered.bridge.world.entity.EntityBridge;
 
 @MixinInfo(events = {"PlayerShearEntityEvent"})
 @Mixin(MushroomCow.class)
@@ -20,10 +23,22 @@ public class MushroomCowMixin {
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/animal/cow/MushroomCow;shear(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/sounds/SoundSource;Lnet/minecraft/world/item/ItemStack;)V"), method = "mobInteract", cancellable = true)
     public void doBukkitEvent_PlayerShearEntityEvent(Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
         ItemStack itemstack = player.getItemInHand(hand);
-        if (!CraftEventFactory.handlePlayerShearEntityEvent(player, (Sheep)(Object)this, itemstack, hand)) {
+        if (!CraftEventFactory.handlePlayerShearEntityEvent(player, (MushroomCow)(Object)this, itemstack, hand)) {
             ci.setReturnValue(InteractionResult.PASS);
             return;
         }
+    }
+
+    @Inject(at = @At("HEAD"),
+    		method = "shear(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/sounds/SoundSource;Lnet/minecraft/world/item/ItemStack;)V")
+    public void cardboardForceDrops_START(ServerLevel world, SoundSource a, ItemStack stack, CallbackInfo ci) {
+        ((EntityBridge)(Object)this).cardboard_setForceDrops(true);
+    }
+
+    @Inject(at = @At("TAIL"),
+    		method = "shear(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/sounds/SoundSource;Lnet/minecraft/world/item/ItemStack;)V")
+    public void cardboardForceDrops_END(ServerLevel world, SoundSource a, ItemStack stack, CallbackInfo ci) {
+        ((EntityBridge)(Object)this).cardboard_setForceDrops(false);
     }
 
 }


### PR DESCRIPTION
## Problem

Shearing a mooshroom throws while the interact packet is handled, so the shear never happens:

```
java.lang.ClassCastException: class net.minecraft.world.entity.animal.cow.MushroomCow cannot be cast to class net.minecraft.world.entity.animal.sheep.Sheep
	at MushroomCow.handler$zdl000$cardboard$doBukkitEvent_PlayerShearEntityEvent(MushroomCow.java:523)
	at MushroomCow.mobInteract(MushroomCow.java:131)
```

`MushroomCowMixin` was casting `this` to `Sheep` before calling `CraftEventFactory.handlePlayerShearEntityEvent`, which actually takes a `net.minecraft.world.entity.Entity`.

## Changes

- Cast to `MushroomCow` instead of `Sheep`.
- Set/clear `forceDrops` around `MushroomCow#shear`, mirroring `SheepMixin`. Without it, `EntityMixin`'s `spawnAtLocation` redirect diverts the sheared mushrooms into the entity's death-drop list instead of spawning them, so a successful shear would drop nothing.

## Testing

`./gradlew compileJava` succeeds.