### PR TITLE
fix: fire EntityTargetLivingEntityEvent for the actual new target

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/MobMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/MobMixin.java
@@ -23,7 +23,10 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
     public LivingEntity target;
 
     @Shadow
-    public abstract @Nullable LivingEntity getTarget();
+    public abstract @Nullable LivingEntity getTargetUnchecked();
+
+    @Shadow
+    protected abstract @Nullable LivingEntity asValidTarget(@Nullable LivingEntity target);
 
     protected MobMixin(EntityType<? extends LivingEntity> entityType, Level level) {
         super(entityType, level);
@@ -32,7 +35,7 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
     @Inject(method = "setTarget", at = @At("HEAD"), cancellable = true)
     public void setTargetCraftBukkit(LivingEntity livingEntity, CallbackInfo ci) {
         // CraftBukkit start - fire event
-        boolean set = this.cardboard$setTarget(target, EntityTargetEvent.TargetReason.UNKNOWN);
+        boolean set = this.cardboard$setTarget(livingEntity, EntityTargetEvent.TargetReason.UNKNOWN);
         if (set) { // Let the other mods call their @Inject if set is false.
             ci.cancel();
         }
@@ -40,12 +43,16 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
 
     @Override
     public boolean cardboard$setTarget(@Nullable LivingEntity target, EntityTargetEvent.@Nullable TargetReason reason) {
-        if (this.getTarget() == target) {
+        // Compare and report against the raw field: getTarget() runs the target through
+        // asValidTarget(), so a stale or dead target reads as null and would both hide a real
+        // change and keep the UNKNOWN reason from being mapped below.
+        LivingEntity oldTarget = this.getTargetUnchecked();
+        if (oldTarget == target) {
             return false;
         }
         if (reason != null) {
-            if (reason == EntityTargetEvent.TargetReason.UNKNOWN && this.getTarget() != null && target == null) {
-                reason = this.getTarget().isAlive() ? EntityTargetEvent.TargetReason.FORGOT_TARGET : EntityTargetEvent.TargetReason.TARGET_DIED;
+            if (reason == EntityTargetEvent.TargetReason.UNKNOWN && oldTarget != null && target == null) {
+                reason = oldTarget.isAlive() ? EntityTargetEvent.TargetReason.FORGOT_TARGET : EntityTargetEvent.TargetReason.TARGET_DIED;
             }
             if (reason == EntityTargetEvent.TargetReason.UNKNOWN) {
                 cardboard$warnUnknownTargetReason(target);
@@ -65,7 +72,7 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
                 target = null;
             }
         }
-        this.target = target;
+        this.target = this.asValidTarget(target); // vanilla setTarget filters the target the same way
         return true;
         // CraftBukkit end
     }
@@ -95,7 +102,7 @@ public abstract class MobMixin extends LivingEntity implements MobBridge, Entity
                 .append(" (uuid=").append(this.getUUID())
                 .append(", world=").append(this.level().dimension().identifier())
                 .append(", pos=").append(this.blockPosition().toShortString())
-                .append("), old target=").append(cardboard$describeTarget(this.getTarget()))
+                .append("), old target=").append(cardboard$describeTarget(this.getTargetUnchecked()))
                 .append(", new target=").append(cardboard$describeTarget(newTarget))
                 .append("\n  called from:");
         for (StackWalker.StackFrame frame : callers) {


### PR DESCRIPTION
## Problem

`MobMixin.setTargetCraftBukkit` passed the shadowed `target` **field** (the current target) to `cardboard$setTarget` instead of the `livingEntity` parameter (the new target):

```java
boolean set = this.cardboard$setTarget(target, EntityTargetEvent.TargetReason.UNKNOWN);
```

So on normal targeting the equality check at the top of `cardboard$setTarget` compared the current target against itself, returned `false`, and `EntityTargetLivingEntityEvent` **never fired** — plugins cannot see or cancel a mob choosing a target.

The check also used `getTarget()`, which in 26.1 is not a plain field read:

```
public net.minecraft.world.entity.LivingEntity getTarget();
   0: aload_0
   1: aload_0
   2: getfield      // Field target
   5: invokevirtual // Method asValidTarget:(...)
```

`asValidTarget` returns `null` for a target that is invulnerable, not `isAlive()`, or a creative/spectator player. Two consequences:

- A real change could look like a no-op, and vice versa.
- The `UNKNOWN` → `TARGET_DIED` / `FORGOT_TARGET` mapping never applied when a goal cleared a dead target, because it requires `target == null` while the stale field was being passed in.

That combination is what produced reports like this one — a zombie villager whose target was removed on conversion, `TargetGoal.stop()` calling `setTarget(null)`, and the mixin reporting the *old* target as the new one:

```
[Server thread/WARN]: Unknown EntityTargetEvent.TargetReason for minecraft:zombie_villager (...), old target=none, new target=minecraft:villager/aa0e4f0c-...
    at Mob.handler$zde000$cardboard$setTargetCraftBukkit(Mob.java:1643)
    at Mob.setTarget(Mob.java)
    at TargetGoal.stop(TargetGoal.java:88)
```

`old target=none` is `asValidTarget()` filtering the removed villager; `new target=<villager>` is the stale field being passed as the new target.

## Changes

- Pass `livingEntity` — the new target — to `cardboard$setTarget`.
- Compare and log against `getTargetUnchecked()` (the raw field) so `asValidTarget` filtering no longer hides changes or blocks the reason mapping.
- On the cancelling path, store `asValidTarget(target)`, the same filtering vanilla `setTarget` applies, so a goal clearing a dead target no longer leaves it in the field.

Vanilla behaviour is unchanged: mobs targeted and attacked correctly before this patch, because the broken path simply skipped the event and let the vanilla body run.

## Note on log volume

Now that the event actually fires, the (rate-limited) `Unknown ... TargetReason` warning will surface once per mob type and call site for every vanilla path Cardboard has not mapped to a `TargetReason` yet. That is the diagnostic doing its job; mapping those call sites is follow-up work.

## Testing

`./gradlew build` succeeds.