### PR TITLE
build: silence the sun.misc.Unsafe proprietary API warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,13 @@ configurations.implementation {
 }
 
 configure([tasks.compileJava]) {
+    // -source/-target rather than --release on purpose: io.izzel.arclight.api.Unsafe has to name
+    // sun.misc.Unsafe, and --release makes javac resolve it from ct.sym, where the mandatory
+    // "internal proprietary API" warning cannot be turned off - not by -Xlint:none, not by
+    // @SuppressWarnings. -XDignore.symbol.file below does silence it, but only without --release.
+    // The toolchain is pinned to the same 25 we target, so this compiles against the same API level.
     sourceCompatibility = 25
-    options.release = 25
+    targetCompatibility = 25
 
     javaCompiler = javaToolchains.compilerFor {
         languageVersion = JavaLanguageVersion.of(25)


### PR DESCRIPTION
## Problem

Every CI compile prints four warnings:

```
Warning: .../io/izzel/arclight/api/Unsafe.java:13: warning: Unsafe is internal proprietary API and may be removed in a future release
Warning: .../io/izzel/arclight/api/Unsafe.java:19: ...
Warning: .../io/izzel/arclight/api/Unsafe.java:21: ...
Warning: .../io/izzel/arclight/api/Unsafe.java:61: ...
```

Those four lines are exactly the places where `io.izzel.arclight.api.Unsafe` names the `sun.misc.Unsafe` *type*. `build.gradle` already tries to suppress this via `-XDignore.symbol.file`, but that flag is inert next to `options.release = 25`: under `--release`, javac resolves `sun.misc.Unsafe` from `ct.sym` and emits the warning regardless.

## Why suppress rather than fix the code

The warning is **mandatory** — it is not a lint category, so it cannot be turned off where it is raised. Measured on javac 25.0.4 with a one-line test class that has `@SuppressWarnings("all")` on it:

| flags | result |
|---|---|
| *(none)* | warning |
| `-XDignore.symbol.file` | silent |
| `-nowarn -Xlint:none` | warning |
| `--release 25 -XDignore.symbol.file` | warning |
| `-source 25 -target 25 -XDignore.symbol.file` | silent |

The `@SuppressWarnings("all")` already on the class does nothing for it either. So the options are: keep the noise, or drop `--release`.

Removing the `sun.misc.Unsafe` usage is not an option in this patch, and not a small one in general. `Unsafe` and `EnumHelper` are what let Cardboard add `Material`, `EntityType` and `PotionType` constants for modded content (`CardboardMagicNumbers`, `RegistryUtil`), and every step of that is closed to supported APIs — writing the private static final `$VALUES` throws `UnsupportedOperationException` through a `VarHandle`, `Class.enumConstants` needs `--add-opens java.base/java.lang`, and `Constructor.newInstance` refuses outright with `Cannot reflectively create enum objects`. That migration is its own design discussion; this PR is only about the log noise.

## Why dropping --release is safe here

`--release` exists to stop you compiling against APIs newer than the target. Here the toolchain is pinned to `JavaLanguageVersion.of(25)` and the target is 25, so `-source 25 -target 25` compiles against the same API level. The class file version is unchanged — `major version: 69` before and after.

The trade-off, stated plainly: if the toolchain is ever bumped above 25 while the target stays 25, `-source/-target` will no longer catch accidental use of newer JDK APIs at compile time. The pinned toolchain in the same block is what keeps that honest.

## Testing

- `./gradlew clean compileJava` before the change: 4 `proprietary` warnings.
- After: 0.
- `./gradlew build` succeeds; emitted class files are still major 69.