### PR TITLE
fix: report the real target reason for NearestAttackableTargetGoal

### DIFF
--- a/src/main/java/org/cardboardpowered/mixin/world/entity/ai/goal/target/NearestAttackableTargetGoalMixin.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/entity/ai/goal/target/NearestAttackableTargetGoalMixin.java
@@ -1,0 +1,32 @@
+package org.cardboardpowered.mixin.world.entity.ai.goal.target;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.player.Player;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.cardboardpowered.bridge.world.entity.MobBridge;
+import org.cardboardpowered.util.MixinInfo;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Reports the reason a mob picked its target through this goal. Going through Mob.setTarget
+ * leaves it as TargetReason.UNKNOWN, which is both useless to plugins and the single loudest
+ * source of the unknown reason warning.
+ */
+@Mixin(NearestAttackableTargetGoal.class)
+@MixinInfo(events = {"EntityTargetLivingEntityEvent"})
+public class NearestAttackableTargetGoalMixin {
+
+    @Redirect(
+            method = "start",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Mob;setTarget(Lnet/minecraft/world/entity/LivingEntity;)V")
+    )
+    private void cardboard$setTargetWithReason(Mob mob, LivingEntity target) {
+        ((MobBridge) mob).cardboard$setTarget(target, target instanceof Player
+                ? EntityTargetEvent.TargetReason.CLOSEST_PLAYER
+                : EntityTargetEvent.TargetReason.CLOSEST_ENTITY);
+    }
+}

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -99,6 +99,7 @@
     "world.entity.ai.behavior.VillagerMakeLoveMixin",
     "world.entity.ai.goal.BreakDoorGoalMixin",
     "world.entity.ai.goal.BreedGoalAccessor",
+    "world.entity.ai.goal.target.NearestAttackableTargetGoalMixin",
     "world.entity.ambient.BatMixin",
     "world.entity.animal.AnimalMixin",
     "world.entity.animal.cow.MushroomCowMixin",


### PR DESCRIPTION
Follow-up to the diagnostic added in d24d0712. That warning asks for unmapped `setTarget` call sites to be reported, and this is the one it fires on constantly:

```
Unknown EntityTargetEvent.TargetReason for minecraft:zombie_villager (...), old target=none, new target=minecraft:villager/...
  called from:
    net.minecraft.world.entity.Mob.handler$...$cardboard$setTargetCraftBukkit(Mob.java:1646)
    net.minecraft.world.entity.Mob.setTarget(Mob.java)
    net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal.start(NearestAttackableTargetGoal.java:69)
    net.minecraft.world.entity.ai.goal.WrappedGoal.start(WrappedGoal.java:42)
```

`NearestAttackableTargetGoal.start()` calls the one-argument `Mob.setTarget`, so `MobMixin.setTargetCraftBukkit` has no reason to work with and fires `EntityTargetLivingEntityEvent` with `TargetReason.UNKNOWN`. A plugin listening for the event cannot tell why the mob picked its target, and since this goal drives most hostile mob targeting it is also the loudest source of the warning.

### Change

Redirect that one call to `MobBridge.cardboard$setTarget` with `CLOSEST_PLAYER` when the target is a player and `CLOSEST_ENTITY` otherwise, which is what CraftBukkit reports for this goal. The bridge already replicates what vanilla `setTarget` does with the value (`this.target = asValidTarget(target)`), the same path `MobMixin` takes today whenever it cancels the vanilla call.

### Testing

Builds clean, dev server boots with the mixin applied and no injection errors. In-game targeting behaviour has not been verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)