### PR TITLE
fix: stop map renderers losing raw iron and the newer map colours

### DIFF
--- a/src/main/java/org/cardboardpowered/impl/map/MapViewImpl.java
+++ b/src/main/java/org/cardboardpowered/impl/map/MapViewImpl.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.logging.Level;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -14,8 +15,10 @@ import org.bukkit.map.MapView;
 
 import org.cardboardpowered.bridge.world.level.LevelBridge;
 import org.cardboardpowered.bridge.world.level.saveddata.maps.MapItemSavedDataBridge;
+import org.cardboardpowered.mixin.world.level.material.MapColorAccessor;
 
 public final class MapViewImpl implements MapView {
+    private static final int PACKED_COLOR_ID_COUNT = countPackedColorIds();
 
     private final Map<CraftPlayer, RenderData> renderCache = new HashMap<>();
     private final List<MapRenderer> renderers = new ArrayList<>();
@@ -116,6 +119,15 @@ public final class MapViewImpl implements MapView {
         return false;
     }
 
+    private static int countPackedColorIds() {
+        MapColor[] colors = MapColorAccessor.cardboard$getMaterialColors();
+        int highest = 0;
+        // The table is sized ahead of what is filled in, so the tail is nulls.
+        for (int id = 0; id < colors.length; ++id)
+            if (colors[id] != null) highest = id;
+        return (highest + 1) * 4;
+    }
+
     public RenderData render(CraftPlayer player) {
         boolean context = isContextual();
         RenderData render = renderCache.get(context ? player : null);
@@ -149,8 +161,7 @@ public final class MapViewImpl implements MapView {
             byte[] buf = canvas.getBuffer();
             for (int i = 0; i < buf.length; ++i) {
                 byte color = buf[i];
-                // There are 208 valid color id's, 0 -> 127 and -128 -> -49
-                if (color >= 0 || color <= -21) render.buffer[i] = color;
+                if ((color & 0xFF) < PACKED_COLOR_ID_COUNT) render.buffer[i] = color;
             }
 
             for (int i = 0; i < canvas.getCursors().size(); ++i)

--- a/src/main/java/org/cardboardpowered/mixin/world/level/material/MapColorAccessor.java
+++ b/src/main/java/org/cardboardpowered/mixin/world/level/material/MapColorAccessor.java
@@ -1,0 +1,21 @@
+package org.cardboardpowered.mixin.world.level.material;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.world.level.material.MapColor;
+
+@Mixin(MapColor.class)
+public interface MapColorAccessor {
+
+    /**
+     * The base colour table, indexed by colour id. Private in vanilla, but the map canvas
+     * needs it to tell a valid packed colour id from an unused one instead of hardcoding
+     * a range that goes stale every time Mojang adds a colour.
+     */
+    @Accessor("MATERIAL_COLORS")
+    static MapColor[] cardboard$getMaterialColors() {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/resources/bukkitfabric.mixins.json
+++ b/src/main/resources/bukkitfabric.mixins.json
@@ -229,6 +229,7 @@
     "world.level.block.state.MixinBlockBehaviour",
     "world.level.border.WorldBorderMixin",
     "world.level.chunk.LevelChunkMixin",
+    "world.level.material.MapColorAccessor",
     "world.level.saveddata.maps.MapItemSavedDataAccessor",
     "world.level.saveddata.maps.MapItemSavedDataMixin",
     "world.level.saveddata.maps.MapItemSavedData_HoldingPlayerMixin",


### PR DESCRIPTION
Plugins that draw images onto maps (ImageCanvas, for example) get transparent holes wherever `raw iron` is the closest palette match.

`MapViewImpl#render` merges each renderer's canvas into the render buffer through a filter inherited from old CraftBukkit:

```java
// There are 208 valid color id's, 0 -> 127 and -128 -> -49
if (color >= 0 || color <= -21) render.buffer[i] = color;
```

Packed colour ids are unsigned, but the comparison is signed. The game now has 62 base colours x 4 brightnesses, so valid ids are 0 -> 247, i.e. bytes `0..127` and `-128..-9`. The `-21` cutoff throws away `-20..-9`:

| `MapColor` | id | packed ids | bytes |
|---|---|---|---|
| `RAW_IRON` | 59 | 236-239 | -20..-17 |
| `GLOW_LICHEN` | 60 | 240-243 | -16..-13 |
| (id 61) | 61 | 244-247 | -12..-9 |

A dropped pixel is left at 0 in `render.buffer`, which is `MapColor.NONE` — a transparent pixel. Bukkit's own `MapPalette` does hand these bytes out (its table has all 248 entries, 236-239 being raw iron), so the plugin side was already correct.

Fixed by comparing unsigned, against a count derived from the vanilla `MapColor` table instead of a hardcoded constant, so the next colour Mojang adds does not silently disappear either. Reading the private table needs a small `@Accessor` mixin.

Compiles; not tested against a live client.